### PR TITLE
add paired-end aligner tool PEAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ nucDB_build=            define the nucleotide translation database build used fo
 humann_count_units=     define units for gene counts [cpm (counts per million), relab (relative abundance), default: cpm]
 dmnd_block_size=        block size to run `DIAMOND`, mem. usage is approximately 6 times this value, increases performance for increased values
 dmnd_num_index_chunks=  number of index chunks to run `DIAMOND` on, lower values increase the performance
+merge_reads=            if true, merge overlapping paired-end reads with `PEAR` instead of just concatenating them [default: true]
 ```
 These can be useful when runnin in environments where the project directory is storage limited and one might want to have large files in other directories without storage limits (this could be the case on shared machines like HPC's where you would want big temporary files on lets say /scratch or similar).\
 NOTE: All of these parameters can be set permanently in the configuration file (profiles/config.yaml).

--- a/Snakefile
+++ b/Snakefile
@@ -13,23 +13,27 @@ WD = {workflow.snakefile}.pop().rsplit('/', 1)[0] + '/'
 SAMPLE = list(SAMPLESHEET["Sample"])
 
 # get file extensions
-EXT = '.' + SAMPLESHEET.loc[0, "R1"].rsplit(".", 2)[1]
+EXT  = '.' + SAMPLESHEET.loc[0, "R1"].rsplit(".", 2)[1]
 EXT += '.' + SAMPLESHEET.loc[0, "R1"].rsplit(".", 2)[2] if SAMPLESHEET.loc[0, "R1"].rsplit(".", 1)[1] == "gz" else + ""
 
 
 READDIR = SAMPLESHEET.loc[0, "R1"].rsplit("/", 1)[0]
-print(READDIR)
+#print(READDIR)
 
 # detect read mode
 SINGLE = True if pd.isna(SAMPLESHEET.loc[0, "R2"]) == 0 else False
 R = ["1"] if SINGLE else ["1", "2"] 
 
-print("samples found:", SAMPLE)
+#print("samples found:", SAMPLE)
 
 
 rule all:
     input:
-        expand("temp/megan/{sample}.done", sample = SAMPLE)
+        expand(config["resultDir"] + "/concat_reads/{sample}_concat.fq", sample = SAMPLE)
+    # pear
+        #expand(config["resultDir"] + "/pear/{sample}.assembled.fastq", sample = SAMPLE)
+    #megan
+        #expand("temp/megan/{sample}.done", sample = SAMPLE)
     # diamond
         #config["cacheDir"] + "/databases/diamond/nr.dmnd"
         #expand( config["resultDir"] + "/diamond/{sample}.daa", sample = SAMPLE)
@@ -40,10 +44,20 @@ rule all:
         #expand("results/{sample}_{r}.{ext}.info", sample = SAMPLE, r = R, ext = EXT)
     #shell:
     #    "rm -r results"
+    onsuccess:
+        print("Workflow finished, startibng cleanup..")
+
+    onerror:
+        print("An error occurred, looking for temporary files to clean up..")
+    message:
+        "rule all"
+
+
 
 
 include: "rules/humann.smk"
 include: "rules/utils.smk"
 include: "rules/diamond.smk"
 include: "rules/megan.smk"
+include: "rules/pear.smk"
 

--- a/envs/pear.yaml
+++ b/envs/pear.yaml
@@ -1,0 +1,7 @@
+name: pear
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - pear==0.9.6

--- a/profiles/config.yaml
+++ b/profiles/config.yaml
@@ -28,4 +28,6 @@ latency-wait: 20
 dmnd_block_size: 12
 
 dmnd_num_index_chunks: 1
-#report: true
+
+# use pear to merge overlapping paired reads
+merge_reads: true

--- a/rules/pear.smk
+++ b/rules/pear.smk
@@ -1,20 +1,30 @@
-rule daa_meganize:
+rule pear:
     input:
         R1 = READDIR + "/{sample}_1" + EXT,
         R2 = READDIR + "/{sample}_2" + EXT
     output:
+        assembled_pairs = config["resultDir"] + "/pear/{sample}.assembled.fastq",
+        unassembled_fwd = config["resultDir"] + "/pear/{sample}.unassembled.forward.fastq",
+        unassembled_rev = config["resultDir"] + "/pear/{sample}.unassembled.reverse.fastq",
+        discarded_reads = config["resultDir"] + "/pear/{sample}.discarded.fastq"
     params:
+        resultDir = config["resultDir"]
     log:
         "log/pear/{sample}_pear.log"
     conda:
         WD + "envs/pear.yaml"
     threads:
-        16
+        8
     message:
         "pear({wildcards.sample})"
     resources:
-        runtime=960
+        runtime=240
     shell:
         """
-        ./pear -f {input.R1} -r {input.R2} -o {output}
+        mkdir -p {params.resultDir}/pear/
+        pear --threads {threads} --forward-fastq {input.R1} --reverse-fastq {input.R2} --output {wildcards.sample} > {log}
+        mv {wildcards.sample}.assembled.fastq {output.assembled_pairs} >> {log}
+        mv {wildcards.sample}.unassembled.forward.fastq {output.unassembled_fwd} >> {log}
+        mv {wildcards.sample}.unassembled.reverse.fastq {output.unassembled_rev} >> {log}
+        mv {wildcards.sample}.discarded.fastq {output.discarded_reads} >> {log}
         """

--- a/rules/pear.smk
+++ b/rules/pear.smk
@@ -1,0 +1,20 @@
+rule daa_meganize:
+    input:
+        R1 = READDIR + "/{sample}_1" + EXT,
+        R2 = READDIR + "/{sample}_2" + EXT
+    output:
+    params:
+    log:
+        "log/pear/{sample}_pear.log"
+    conda:
+        WD + "envs/pear.yaml"
+    threads:
+        16
+    message:
+        "pear({wildcards.sample})"
+    resources:
+        runtime=960
+    shell:
+        """
+        ./pear -f {input.R1} -r {input.R2} -o {output}
+        """

--- a/rules/utils.smk
+++ b/rules/utils.smk
@@ -1,9 +1,21 @@
+def get_concat_input(wildcards):
+    if config["merge_reads"] == "true":
+        dd = {  "assembled_pairs": config["resultDir"] + "/pear/{wildcards.sample}.assembled.fastq".format(wildcards=wildcards),
+                "unassembled_fwd": config["resultDir"] + "/pear/{wildcards.sample}.unassembled.forward.fastq".format(wildcards=wildcards),
+                "unassembled_rev": config["resultDir"] + "/pear/{wildcards.sample}.unassembled.reverse.fastq".format(wildcards=wildcards),
+                "discarded_reads": config["resultDir"] + "/pear/{wildcards.sample}.discarded.fastq".format(wildcards=wildcards) }
+    else:
+        dd = {  "R1": READDIR + "/{wildcards.sample}_1".format(wildcards=wildcards) + EXT,
+                "R2": READDIR + "/{wildcards.sample}_2".format(wildcards=wildcards) + EXT }
+    return dd
+
+
+
 rule concat_paired_reads:
     input: 
-        R1 = READDIR + "/{sample}_1" + EXT,
-        R2 = READDIR + "/{sample}_2" + EXT
+        unpack(get_concat_input)
     output: 
-        config["resultDir"] + "/concat_reads/{sample}_concat.fq" + EXT 
+        config["resultDir"] + "/concat_reads/{sample}_concat.fq"
     log:
         "log/concat_paired_reads/{sample}_concat.log"
     conda:
@@ -14,5 +26,5 @@ rule concat_paired_reads:
         "concat_paired_reads({wildcards.sample})"
     shell: 
         """
-        cat {input.R1} {input.R1} > {output}
+        cat {input} > {output}
         """

--- a/scripts/create_input_csv.py
+++ b/scripts/create_input_csv.py
@@ -27,7 +27,7 @@ def main(args=None):
     with open('input.csv', 'w') as f:
         print("Sample,R1,R2", file=f)
         for SRR in dict(dictionary):
-            print(f"{SRR.strip()},{WD + dict(dictionary)[SRR][0].strip()},{WD + dict(dictionary)[SRR][1].strip()}", file=f)
+            print(f"{SRR.strip()},{WD + '/' + dict(dictionary)[SRR][0].strip()},{WD + '/' + dict(dictionary)[SRR][1].strip()}", file=f)
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
If run with `--config merge_reads=true` the pipeline will merge paired-end input reads that overlap with `PEAR` before concatenating them to a single file for `DIAMOND` input.
- added documentation
- added `onsuccess` and `onerror` messages to `rule all`