### PR TITLE
filter host sequences if reference file(s) is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ humann_count_units=     define units for gene counts [cpm (counts per million), 
 dmnd_block_size=        block size to run `DIAMOND`, mem. usage is approximately 6 times this value, increases performance for increased values
 dmnd_num_index_chunks=  number of index chunks to run `DIAMOND` on, lower values increase the performance
 merge_reads=            if true, merge overlapping paired-end reads with `PEAR` instead of just concatenating them [default: true]
+bowtie2_reference=      directory containing the host genome file(s) used for removing host sequences from the reads
 ```
 These can be useful when runnin in environments where the project directory is storage limited and one might want to have large files in other directories without storage limits (this could be the case on shared machines like HPC's where you would want big temporary files on lets say /scratch or similar).\
 NOTE: All of these parameters can be set permanently in the configuration file (profiles/config.yaml).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ humann_count_units=     define units for gene counts [cpm (counts per million), 
 dmnd_block_size=        block size to run `DIAMOND`, mem. usage is approximately 6 times this value, increases performance for increased values
 dmnd_num_index_chunks=  number of index chunks to run `DIAMOND` on, lower values increase the performance
 merge_reads=            if true, merge overlapping paired-end reads with `PEAR` instead of just concatenating them [default: true]
-bowtie2_reference=      directory containing the host genome file(s) used for removing host sequences from the reads
+bowtie2_reference=      directory containing the host genome file(s) used for removing host sequences from the reads [default: empty]
 ```
 These can be useful when runnin in environments where the project directory is storage limited and one might want to have large files in other directories without storage limits (this could be the case on shared machines like HPC's where you would want big temporary files on lets say /scratch or similar).\
 NOTE: All of these parameters can be set permanently in the configuration file (profiles/config.yaml).

--- a/Snakefile
+++ b/Snakefile
@@ -1,5 +1,6 @@
 #snakemake --config yourparam=1.5
 import pandas as pd
+import glob
 
 configfile: "profiles/config.yaml"
 
@@ -29,7 +30,8 @@ R = ["1"] if SINGLE else ["1", "2"]
 
 rule all:
     input:
-        expand(config["resultDir"] + "/concat_reads/{sample}_concat.fq", sample = SAMPLE)
+        expand(config["resultDir"] + "/bowtie2/{sample}_unmapped.fastq.gz", sample = SAMPLE)
+        #expand(config["resultDir"] + "/concat_reads/{sample}_concat.fq", sample = SAMPLE)
     # pear
         #expand(config["resultDir"] + "/pear/{sample}.assembled.fastq", sample = SAMPLE)
     #megan
@@ -44,13 +46,14 @@ rule all:
         #expand("results/{sample}_{r}.{ext}.info", sample = SAMPLE, r = R, ext = EXT)
     #shell:
     #    "rm -r results"
-    onsuccess:
-        print("Workflow finished, startibng cleanup..")
-
-    onerror:
-        print("An error occurred, looking for temporary files to clean up..")
     message:
         "rule all"
+
+onsuccess:
+    print("Workflow finished, startibng cleanup..")
+
+onerror:
+    print("An error occurred, looking for temporary files to clean up..")
 
 
 
@@ -60,4 +63,5 @@ include: "rules/utils.smk"
 include: "rules/diamond.smk"
 include: "rules/megan.smk"
 include: "rules/pear.smk"
+include: "rules/bowtie2.smk"
 

--- a/Snakefile
+++ b/Snakefile
@@ -50,7 +50,7 @@ rule all:
         "rule all"
 
 onsuccess:
-    print("Workflow finished, startibng cleanup..")
+    print("Workflow finished, starting cleanup..")
 
 onerror:
     print("An error occurred, looking for temporary files to clean up..")

--- a/envs/bowtie2.yaml
+++ b/envs/bowtie2.yaml
@@ -1,0 +1,8 @@
+name: bowtie2
+channels:
+  - bioconda
+  - conda-forge
+  - anaconda
+  - r
+dependencies:
+  - bowtie2==2.4.4

--- a/profiles/config.yaml
+++ b/profiles/config.yaml
@@ -31,3 +31,5 @@ dmnd_num_index_chunks: 1
 
 # use pear to merge overlapping paired reads
 merge_reads: true
+
+bowtie2_reference: ""

--- a/rules/bowtie2.smk
+++ b/rules/bowtie2.smk
@@ -15,8 +15,8 @@ rule bowtie2_index:
         rev_one = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1] + "/index.rev.1.bt2l",
         rev_two = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1] + "/index.rev.2.bt2l"
     params:
-        index_out_dir   = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1],
-        index_in_dir    = config["bowtie2_reference"]
+        index_dir   = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1],
+        ref_dir     = config["bowtie2_reference"]
     log:
         "log/bowite2/bowtie2_index.log"
     conda:
@@ -29,10 +29,10 @@ rule bowtie2_index:
         runtime=240
     shell:
         """
-        cat {input} > {params.index_in_dir}_concat.fa 2> {log}
-        bowtie2-build --large-index --threads {threads} {params.index_in_dir}_concat.fa {params.index_out_dir}/index 2> {log}
-        export BOWTIE2_INDEXES={params.index_out_dir} 2> {log}
-        rm {params.index_in_dir}_concat.fa 2> {log}
+        cat {input} > {params.ref_dir}_concat.fa 2> {log}
+        bowtie2-build --large-index --threads {threads} {params.ref_dir}_concat.fa {params.index_dir}/index 2> {log}
+        export BOWTIE2_INDEXES={params.index_dir} 2> {log}
+        rm {params.ref_dir}_concat.fa 2> {log}
         """
 
 rule bowtie2_map:
@@ -47,7 +47,7 @@ rule bowtie2_map:
     output:
         unmapped = config["resultDir"] + "/bowtie2/{sample}_unmapped.fastq.gz"
     params:
-        out_dir  = config["resultDir"] + "/bowtie2/"
+        ref_dir  = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1]
     log:
         "log/bowite2/bowtie2_map_{sample}.log"
     conda:
@@ -60,5 +60,5 @@ rule bowtie2_map:
         runtime=480
     shell:
         """
-        bowtie2 -x index -U {input.reads} --un-gz {params.out_dir} 2> {log}
+        bowtie2 -x {params.ref_dir}/index -U {input.reads} --un-gz {output.unmapped} 2> {log}
         """

--- a/rules/bowtie2.smk
+++ b/rules/bowtie2.smk
@@ -1,23 +1,22 @@
-#align
-#bowtie2 -x example/index/lambda_virus -1 example/reads/reads_1.fq -2 example/reads/reads_2.fq
-
-# Building a small index
-#bowtie2-build example/reference/lambda_virus.fa example/index/lambda_virus
-
-# Building a large index
-#bowtie2-build --large-index example/reference/lambda_virus.fa example/index/lambda_virus
+def get_references(wildcards):
+    file_paths = []
+    for file in glob.glob(config["bowtie2_reference"] + "/*"):
+        file_paths.append(file)
+    return file_paths
 
 rule bowtie2_index:
+    input:  
+        get_references
     output:
-        one     = config["cacheDir"] + "bowtie2/" + config["bowtie2_reference"] + "/index.1.bt2l",
-        two     = config["cacheDir"] + "bowtie2/" + config["bowtie2_reference"] + "/index.2.bt2l",
-        three   = config["cacheDir"] + "bowtie2/" + config["bowtie2_reference"] + "/index.3.bt2l",
-        four    = config["cacheDir"] + "bowtie2/" + config["bowtie2_reference"] + "/index.4.bt2l",
-        rev_one = config["cacheDir"] + "bowtie2/" + config["bowtie2_reference"] + "/index.rev.1.bt2l",
-        rev_two = config["cacheDir"] + "bowtie2/" + config["bowtie2_reference"] + "/index.rev.2.bt2l"
+        one     = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1] + "/index.1.bt2l",
+        two     = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1] + "/index.2.bt2l",
+        three   = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1] + "/index.3.bt2l",
+        four    = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1] + "/index.4.bt2l",
+        rev_one = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1] + "/index.rev.1.bt2l",
+        rev_two = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1] + "/index.rev.2.bt2l"
     params:
-        reference       = config["bowtie2_reference"],
-        index_dir       = config["cacheDir"] + "bowtie2/index/" + config["bowtie2_reference"],
+        index_out_dir   = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1],
+        index_in_dir    = config["bowtie2_reference"]
     log:
         "log/bowite2/bowtie2_index.log"
     conda:
@@ -30,6 +29,36 @@ rule bowtie2_index:
         runtime=240
     shell:
         """
-        bowtie2-build --large-index --threads {threads} {params.reference} index
-        mv *.bt2l {params.index_dir}
+        cat {input} > {params.index_in_dir}_concat.fa 2> {log}
+        bowtie2-build --large-index --threads {threads} {params.index_in_dir}_concat.fa {params.index_out_dir}/index 2> {log}
+        export BOWTIE2_INDEXES={params.index_out_dir} 2> {log}
+        rm {params.index_in_dir}_concat.fa 2> {log}
+        """
+
+rule bowtie2_map:
+    input:
+        one     = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1] + "/index.1.bt2l",
+        two     = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1] + "/index.2.bt2l",
+        three   = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1] + "/index.3.bt2l",
+        four    = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1] + "/index.4.bt2l",
+        rev_one = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1] + "/index.rev.1.bt2l",
+        rev_two = config["cacheDir"] + "/bowtie2/" + config["bowtie2_reference"].split("/")[-1] + "/index.rev.2.bt2l",
+        reads   = config["resultDir"] + "/concat_reads/{sample}_concat.fq"
+    output:
+        unmapped = config["resultDir"] + "/bowtie2/{sample}_unmapped.fastq.gz"
+    params:
+        out_dir  = config["resultDir"] + "/bowtie2/"
+    log:
+        "log/bowite2/bowtie2_map_{sample}.log"
+    conda:
+        WD + "envs/bowtie2.yaml"
+    threads:
+        16
+    message:
+        "bowtie2_map({wildcards.sample})"
+    resources:
+        runtime=480
+    shell:
+        """
+        bowtie2 -x index -U {input.reads} --un-gz {params.out_dir} 2> {log}
         """

--- a/rules/bowtie2.smk
+++ b/rules/bowtie2.smk
@@ -1,0 +1,35 @@
+#align
+#bowtie2 -x example/index/lambda_virus -1 example/reads/reads_1.fq -2 example/reads/reads_2.fq
+
+# Building a small index
+#bowtie2-build example/reference/lambda_virus.fa example/index/lambda_virus
+
+# Building a large index
+#bowtie2-build --large-index example/reference/lambda_virus.fa example/index/lambda_virus
+
+rule bowtie2_index:
+    output:
+        one     = config["cacheDir"] + "bowtie2/" + config["bowtie2_reference"] + "/index.1.bt2l",
+        two     = config["cacheDir"] + "bowtie2/" + config["bowtie2_reference"] + "/index.2.bt2l",
+        three   = config["cacheDir"] + "bowtie2/" + config["bowtie2_reference"] + "/index.3.bt2l",
+        four    = config["cacheDir"] + "bowtie2/" + config["bowtie2_reference"] + "/index.4.bt2l",
+        rev_one = config["cacheDir"] + "bowtie2/" + config["bowtie2_reference"] + "/index.rev.1.bt2l",
+        rev_two = config["cacheDir"] + "bowtie2/" + config["bowtie2_reference"] + "/index.rev.2.bt2l"
+    params:
+        reference       = config["bowtie2_reference"],
+        index_dir       = config["cacheDir"] + "bowtie2/index/" + config["bowtie2_reference"],
+    log:
+        "log/bowite2/bowtie2_index.log"
+    conda:
+        WD + "envs/bowtie2.yaml"
+    threads:
+        16
+    message:
+        "bowtie2_index"
+    resources:
+        runtime=240
+    shell:
+        """
+        bowtie2-build --large-index --threads {threads} {params.reference} index
+        mv *.bt2l {params.index_dir}
+        """

--- a/rules/diamond.smk
+++ b/rules/diamond.smk
@@ -1,6 +1,12 @@
 def get_blast_mem(wildcards, attempt):
     return ((config["dmnd_block_size"] * 7 + config["dmnd_block_size"] * attempt) * 1024)
 
+def get_diamond_reads(wildcards):
+    if config["bowtie2_reference"] != "":
+        return config["resultDir"] + "/bowtie2/{wildcards.sample}_unmapped.fastq.gz"
+    else:
+        return config["resultDir"] + "/concat_reads/{wildcards.sample}_concat.fq" + EXT
+
 rule diamond_makedb:
     output:
         config["cacheDir"] + "/databases/diamond/nr.dmnd"
@@ -27,7 +33,7 @@ rule diamond_makedb:
 rule diamond_blastx:
     input:
         db      = config["cacheDir"] + "/databases/diamond/nr.dmnd",
-        reads   = config["resultDir"] + "/concat_reads/{sample}_concat.fq" + EXT
+        reads   = get_diamond_reads
     output: 
         config["resultDir"] + "/diamond/{sample}.daa"
     params:

--- a/rules/humann.smk
+++ b/rules/humann.smk
@@ -1,3 +1,9 @@
+def get_humann_reads(wildcards):
+    if config["bowtie2_reference"] != "":
+        return config["resultDir"] + "/bowtie2/{wildcards.sample}_unmapped.fastq.gz"
+    else:
+        return config["resultDir"] + "/concat_reads/{wildcards.sample}_concat.fq" + EXT
+
 rule humann_databases:
     log:
         c = "log/humann/humann_databases_ChocoPhlAn.log",
@@ -26,7 +32,7 @@ rule humann_compute:
     input: 
         nucDB   = config["cacheDir"] + "/databases/humann/nuc",
         protDB  = config["cacheDir"] + "/databases/humann/prot",
-        reads   = config["resultDir"] + "/concat_reads/{sample}_concat.fq" + EXT
+        reads   = get_humann_reads
     output: 
         genefamilies    = config["resultDir"] + "/humann/raw/{sample}_genefamilies.tsv",
         pathways        = config["resultDir"] + "/humann/raw/{sample}_pathabundance.tsv",


### PR DESCRIPTION
- If a reference genome is specified via the `bowtie2_reference=` parameter the pipeline will map the merged and concatenated reads against the reference genome and only keep reads that didn't map. Those will then be further processed by either `DIAMOND` -> `MEGAN6` or `DIAMND`-> `humann` etc..
- added documentation accordingly