### PR TITLE
read in resources from resource config, closes #22

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,6 +1,7 @@
 import pandas as pd
 import glob
 import os
+import yaml
 
 configfile: "profiles/config.yaml"
 include: "scripts/create_input_csv.py"

--- a/profiles/config.yaml
+++ b/profiles/config.yaml
@@ -41,8 +41,8 @@ sThreshold: "10"
 min_adpt_len: 8
 
 #dga
-metadata_csv: "assets/test-data/contrasts.csv"
-contrast_csv: "assets/test-data/metadata.csv"
+metadata_csv: "assets/test_data/contrast.csv"
+contrast_csv: "assets/test_data/metadata.csv"
 formula: ""
 plot_height: 11
 plot_width: 11

--- a/profiles/resource.yaml
+++ b/profiles/resource.yaml
@@ -13,6 +13,7 @@ humann_join:          {cpu: 1, mem: 1, time: 1}
 humann_database:      {cpu: 1, mem: 1, time: 1}
 humann_normalize:     {cpu: 1, mem: 1, time: 1}
 join_megan_tsv:       {cpu: 1, mem: 1, time: 1}
+mega_get_db:          {cpu: 1, mem: 1, time: 1}
 multiqc:              {cpu: 1, mem: 1, time: 1}
 trimmomatic:          {cpu: 1, mem: 1, time: 1}
 dga_analysis:         {cpu: 1, mem: 1, time: 1}

--- a/rules/analysis.smk
+++ b/rules/analysis.smk
@@ -1,7 +1,7 @@
 def dga_counts(wildcards):
 
-    humann  = os.path.join(RESULTDIR, "humann", "genefamilies_" + UNITS  + "_combined.tsv")
-    megan   = os.path.join(RESULTDIR, "megan", "megan_combined.csv")
+    humann  = [ os.path.join(RESULTDIR, "humann", "genefamilies_" + UNITS  + "_combined.tsv")    ]
+    megan   = [ os.path.join(RESULTDIR, "megan", "megan_combined.csv")  ]
 
     if "humann" in CORETOOLS and not "megan" in CORETOOLS: return humann
     elif "megan" in CORETOOLS and not "humann" in CORETOOLS: return megan
@@ -11,17 +11,17 @@ rule differential_gene_analysis:
     input: 
         counts      = dga_counts,
         metadata    = config["metadata_csv"],
-        comparisons = config["comparisons_csv"]
+        comparisons = config["contrast_csv"]
     output:
-        flag        = os.path.join(TEMP, "dga_humann.done")
+        flag        = os.path.join(TEMPDIR, "dga_{sample}.done")
     log:
-        os.path.join("log", "humann", "normalize", "{sample}_humann.log")
+        os.path.join("log", "dga", "dga_{sample}.log")
     conda:
         os.path.join("..", "envs", "analysis.yaml")
     threads:
-        8
+        RES["dga_analysis"]["cpu"]
     resources:
-        time=240
+        time = RES["dga_analysis"]["time"]
     params:
         tmp_dir     = TEMPDIR,
         formula     = FORMULA,

--- a/rules/bbmerge.smk
+++ b/rules/bbmerge.smk
@@ -18,12 +18,12 @@ rule bbmerge:
     conda:
         os.path.join("..", "envs", "bbmerge.yaml")
     threads:
-        16
+        RES["bbmerge"]["cpu"]
     message:
         "bbmerge({wildcards.sample})"
     resources:
-        time=480,
-        mem_mb=10240
+        time = RES["bbmerge"]["time"],
+        mem_mb = RES["bbmerge"]["mem"]
     shell:
         """
         bbmerge.sh t={threads} ziplevel=5 default -Xmx10240m in1={input.R1} in2={input.R2} out={output.merged} outu={output.unmerged} ihist={output.inserthist} 2> {log}

--- a/rules/bowtie2.smk
+++ b/rules/bowtie2.smk
@@ -22,11 +22,11 @@ rule bowtie2_index:
     conda:
         os.path.join("..", "envs", "bowtie2.yaml")
     threads:
-        16
+        RES["bowtie2-index"]["cpu"]
     message:
         "bowtie2_index"
     resources:
-        time=240
+        time = RES["bowtie2-index"]["time"]
     shell:
         """
         cat {input} > {params.ref_dir}_concat.fa 2> {log}
@@ -63,11 +63,11 @@ rule bowtie2_map:
     conda:
         os.path.join("..", "envs", "bowtie2.yaml")
     threads:
-        28
+        RES["bowtie2-map"]["cpu"]
     message:
         "bowtie2_map({wildcards.sample})"
     resources:
-        time=lambda _, attempt: 480 + ((attempt - 1) * 480)
+        time=lambda _, attempt: RES["bowtie2-map"]["time"] + ((attempt - 1) * RES["bowtie2-map"]["time"])
     shell:
         """
         bowtie2 --quiet {params.file_format} -x {params.ref_dir}/index -U {input.reads} --un-gz {output.unmapped} 2> {log} > /dev/null

--- a/rules/diamond.smk
+++ b/rules/diamond.smk
@@ -1,5 +1,5 @@
 def get_blast_mem(wildcards, attempt):
-    return ((BLOCK_SIZE * 7 + BLOCK_SIZE * attempt) * 1024)
+    return ((BLOCK_SIZE * 7 + BLOCK_SIZE * attempt) * RES["diamond_blastx"]["mem"])
 
 def get_diamond_reads(wildcards):
     if REFERENCE != "":
@@ -14,11 +14,11 @@ rule diamond_makedb:
         prot_ref_db_src = "https://ftp.ncbi.nlm.nih.gov/blast/db/FASTA/nr.gz",
         prot_ref_db_dir = os.path.join(CACHEDIR, "databases", "protein_reference")
     threads:
-        16
+        RES["diamond_makedb"]["cpu"]
     conda:
         os.path.join("..", "envs", "diamond.yaml")
     resources:
-        time=1200
+        time = RES["diamond_makedb"]["time"]
     message:
         "diamond_makedb"
     log:
@@ -42,11 +42,11 @@ rule diamond_blastx:
     conda:
         os.path.join("..", "envs", "diamond.yaml")
     resources:
-        time=2880,
+        time = RES["diamond_blastx"]["time"],
         mem_mb=get_blast_mem,
         partition="big"
     threads:
-        24
+        RES["diamond_blastx"]["cpu"]
     message:
         "diamond_blastx({wildcards.sample})"
     log:

--- a/rules/fastqc.smk
+++ b/rules/fastqc.smk
@@ -8,7 +8,7 @@ rule fastqc_pe:
     log:
         os.path.join("log", "fastqc", "{sample}_{mate}.log")
     threads: 
-        1
+        RES["fastqc"]["cpu"]
     message:
         "fastqc_pre({wildcards.sample}_{wildcards.mate})"
     wrapper:
@@ -25,7 +25,7 @@ rule fastqc_se:
     log:
         os.path.join("log", "fastqc", "{sample}.log")
     threads: 
-        1
+        RES["fastqc"]["cpu"]
     message:
         "fastqc_se({wildcards.sample})"
     wrapper:

--- a/rules/humann.smk
+++ b/rules/humann.smk
@@ -18,9 +18,9 @@ rule humann_databases:
     conda:
         os.path.join("..", "envs", "humann.yaml")
     resources:
-        time=240
+        time = RES["humann_database"]["time"]
     threads:
-        2
+        RES["humann_database"]["cpu"]
     message:
         "humann_database"
     shell:
@@ -44,9 +44,9 @@ rule humann_compute:
     conda:
         os.path.join("..", "envs", "humann.yaml")
     threads:
-        24
+        RES["humann_compute"]["cpu"]
     resources:
-        time=1200,
+        time = RES["humann_compute"]["time"],
         partition="big"
     params:
         outdir      = os.path.join(RESULTDIR, "humann", "raw", "{sample}_genefamilies.tsv").rsplit('/',1)[0],
@@ -71,9 +71,9 @@ rule humann_join:
     conda:
         os.path.join("..", "envs", "humann.yaml")
     threads:
-        8
+        RES["humann_join"]["cpu"]
     resources:
-        time=240
+        time = RES["humann_join"]["time"]
     params:
         tabledir    = os.path.join(RESULTDIR, "humann", "raw", "{sample}_genefamilies.tsv").rsplit('/',1)[0]
     message:
@@ -100,9 +100,9 @@ rule humann_normalize:
     conda:
         os.path.join("..", "envs", "humann.yaml")
     threads:
-        8
+        RES["humann_normalize"]["cpu"]
     resources:
-        time=240
+        time = RES["humann_normalize"]["time"]
     params:
         outdir = os.path.join(RESULTDIR, "humann"),
         units = UNITS

--- a/rules/megan.smk
+++ b/rules/megan.smk
@@ -4,7 +4,9 @@ rule megan_get_db:
     conda:
        os.path.join("..", "envs", "utils.yaml")
     resources:
-        time=120
+        time = RES["megan_get_db"]["time"]
+    threads:
+        RES["megan_get_db"]["cpu"]
     message:
         "megan_get_db"
     log:
@@ -30,11 +32,11 @@ rule daa_meganize:
     conda:
         os.path.join("..", "envs", "megan.yaml")
     threads:
-        16
+        RES["daa_meganize"]["cpu"]
     message:
         "daa_meganize({wildcards.sample})"
     resources:
-        time=1200,
+        time = RES["daa_meganize"]["time"],
         partition="big"
     shell:
         """
@@ -62,7 +64,7 @@ rule daa_to_info:
     params:
         outdir = os.path.join(RESULTDIR, "megan", "counts")
     threads:
-        1
+        RES["daa_to_info"]["cpu"]
     message:
         "daa_to_info({wildcards.sample})"
     shell:
@@ -80,6 +82,8 @@ rule join_megan_tsv:
         combined = os.path.join(RESULTDIR, "megan", "megan_combined.csv")
     message:
         "join_megan_tsv"
+    threads:
+        RES["join_megan_tsv"]["cpu"]
     run:
         frames = [ pd.read_csv(f, sep='\t', index_col=0, names=["gene_id", f]) for f in input ]
         result = frames[0].join(frames[1:])

--- a/rules/multiqc.smk
+++ b/rules/multiqc.smk
@@ -26,5 +26,7 @@ rule multiqc:
         os.path.join("log", "multiqc.log")
     message:
         "multiqc"
+    threads:
+        RES["multiqc"]["cpu"]
     wrapper:
         "v0.86.0/bio/multiqc"

--- a/rules/pear.smk
+++ b/rules/pear.smk
@@ -21,11 +21,11 @@ rule pear:
     conda:
         os.path.join("..", "envs", "pear.yaml")
     threads:
-        8
+        RES["pear"]["cpu"]
     message:
         "pear({wildcards.sample})"
     resources:
-        time=240
+        time = RES["pear"]["time"]
     shell:
         """
         mkdir -p {params.resultDir}/pear/

--- a/rules/trimmomatic.smk
+++ b/rules/trimmomatic.smk
@@ -21,9 +21,9 @@ rule trimmomatic_pe:
         extra="",
         compression_level="-9"
     threads:
-        32
+        RES["trimmomatic"]["cpu"]
     resources:
-        mem_mb=1024
+        mem_mb = RES["trimmomatic"]["mem"]
     message:
         "trimmomatic_pe({wildcards.sample})"
     wrapper:
@@ -46,9 +46,9 @@ rule trimmomatic_se:
         # optional compression levels from -0 to -9 and -11
         compression_level="-9"
     threads:
-        32
+        RES["trimmomatic"]["cpu"]
     resources:
-        mem_mb=1024
+        mem_mb = RES["trimmomatic"]["mem"]
     message:
         "trimmomatic_se({wildcards.sample})"
     wrapper:

--- a/rules/utils.smk
+++ b/rules/utils.smk
@@ -27,7 +27,7 @@ rule concat_paired_reads:
     conda:
         os.path.join("..", "envs", "utils.yaml")
     threads:
-        1
+        RES["concat_paired_reads"]["cpu"]
     message:
         "concat_paired_reads({wildcards.sample})"
     shell: 


### PR DESCRIPTION
Put all the resources into one config file so one can have easy access to it instead of looking in every rule to change resources.